### PR TITLE
Fix code quality items frequently being detected as new and cleared enmass (due to different build paths on multiple runners)

### DIFF
--- a/src/DotNet.GitlabCodeQualityBuildLogger/CodeQualityReport.cs
+++ b/src/DotNet.GitlabCodeQualityBuildLogger/CodeQualityReport.cs
@@ -30,7 +30,8 @@ public sealed class CodeQualityIssue
         string severity)
     {
         var description = $"{checkName}: {message}";
-        var fingerprint = GenerateFingerprint(filePath, line, checkName, message);
+        var filePathNormalized = NormalizePath(filePath);
+        var fingerprint = GenerateFingerprint(filePathNormalized, line, checkName, message);
 
         return new CodeQualityIssue
         {
@@ -40,7 +41,7 @@ public sealed class CodeQualityIssue
             Severity = severity,
             Location = new CodeQualityLocation
             {
-                Path = NormalizePath(filePath),
+                Path = NormalizePath(filePathNormalized),
                 Lines = new CodeQualityLines { Begin = line > 0 ? line : 1 }
             }
         };


### PR DESCRIPTION

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
I had not created an issue, but can create one if requested.

## Description
Updated CodeQualityReport.cs to generate fingerprint from the normalized filepath instead of the pre-normalized filepath.
as on different runners we have different filepaths. the normalization process strips out that difference, but the fingerprint was calculated from the prenormalized path.

